### PR TITLE
Fix mobile logged out screen element movement

### DIFF
--- a/src/components/hub/EmbeddedLoginForm.css
+++ b/src/components/hub/EmbeddedLoginForm.css
@@ -115,8 +115,11 @@
   transition: color 0.3s ease;
 }
 
-.passwordToggle:hover {
-  color: #fff;
+/* Only apply hover effects on devices that support hover (desktop) */
+@media (hover: hover) and (pointer: fine) {
+  .passwordToggle:hover {
+    color: #fff;
+  }
 }
 
 .pinLoginBtn {
@@ -133,10 +136,13 @@
   margin-bottom: 0.5rem;
 }
 
-.pinLoginBtn:hover:not(:disabled) {
-  background: linear-gradient(45deg, #c53030, #e53e3e);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(229, 62, 62, 0.4);
+/* Only apply hover effects on devices that support hover (desktop) */
+@media (hover: hover) and (pointer: fine) {
+  .pinLoginBtn:hover:not(:disabled) {
+    background: linear-gradient(45deg, #c53030, #e53e3e);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(229, 62, 62, 0.4);
+  }
 }
 
 .pinLoginBtn:disabled {

--- a/src/components/hub/EmbeddedLoginForm.jsx
+++ b/src/components/hub/EmbeddedLoginForm.jsx
@@ -222,12 +222,16 @@ export default function EmbeddedLoginForm({ onSuccess, onShowSignup }) {
               minHeight: isMobile ? '24px' : 'auto' // Much smaller height on mobile
             }}
             onMouseEnter={(e) => {
-              e.target.style.background = '#FF6B35';
-              e.target.style.color = 'white';
+              if (window.innerWidth > 768) {
+                e.target.style.background = '#FF6B35';
+                e.target.style.color = 'white';
+              }
             }}
             onMouseLeave={(e) => {
-              e.target.style.background = 'transparent';
-              e.target.style.color = '#FF6B35';
+              if (window.innerWidth > 768) {
+                e.target.style.background = 'transparent';
+                e.target.style.color = '#FF6B35';
+              }
             }}
           >
             🆕 First Time User? Apply for Access

--- a/src/components/hub/LoggedOutHub.jsx
+++ b/src/components/hub/LoggedOutHub.jsx
@@ -114,12 +114,16 @@ const LoggedOutHub = ({ onLoginSuccess }) => {
                 transition: 'all 0.3s ease'
               }}
               onMouseEnter={(e) => {
-                e.target.style.background = '#e53e3e';
-                e.target.style.color = 'white';
+                if (window.innerWidth > 768) {
+                  e.target.style.background = '#e53e3e';
+                  e.target.style.color = 'white';
+                }
               }}
               onMouseLeave={(e) => {
-                e.target.style.background = 'transparent';
-                e.target.style.color = '#e53e3e';
+                if (window.innerWidth > 768) {
+                  e.target.style.background = 'transparent';
+                  e.target.style.color = '#e53e3e';
+                }
               }}
             >
               ← Back to Login
@@ -183,12 +187,16 @@ const LoggedOutHub = ({ onLoginSuccess }) => {
                           transition: 'all 0.3s ease'
                         }}
                         onMouseEnter={(e) => {
-                          e.target.style.background = app.id === 'ladder' ? '#4CAF50' : app.color;
-                          e.target.style.color = 'white';
+                          if (window.innerWidth > 768) {
+                            e.target.style.background = app.id === 'ladder' ? '#4CAF50' : app.color;
+                            e.target.style.color = 'white';
+                          }
                         }}
                         onMouseLeave={(e) => {
-                          e.target.style.background = 'transparent';
-                          e.target.style.color = app.id === 'ladder' ? '#4CAF50' : app.color;
+                          if (window.innerWidth > 768) {
+                            e.target.style.background = 'transparent';
+                            e.target.style.color = app.id === 'ladder' ? '#4CAF50' : app.color;
+                          }
                         }}
                       >
                         👀 Access as Guest


### PR DESCRIPTION
Prevent elements from moving/jumping on mobile taps by restricting hover effects to desktop.

Mobile browsers can sometimes trigger mouse events (like `onMouseEnter`/`onMouseLeave` and CSS `:hover`) on touch, causing elements to unexpectedly shift or change appearance. This PR addresses this by adding `window.innerWidth` checks to JavaScript hover handlers and using `@media (hover: hover) and (pointer: fine)` queries for CSS hover styles, ensuring these effects only apply on devices with true hover capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f017a08-0c61-49be-a6a6-b6fecdec7f9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f017a08-0c61-49be-a6a6-b6fecdec7f9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

